### PR TITLE
Scale to 8x jammy-vm and 4x focal-vm runners

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -23,5 +23,5 @@ jobs:
     secrets: inherit
     with:
       balena_slugs: |
-        balena/github-runners-amd64,
-        balena/github-runners-aarch64
+        product_os/github-runners-amd64,
+        product_os/github-runners-aarch64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ x-runner-vm:
     GITHUB_ENTERPRISE: balena
     # register to the self-hosted runner group allowed on public repositories
     ACTIONS_RUNNER_GROUP: self-hosted
-    # limit VM memory to 32GB, or the host total memory, whichever is lower
-    MEM_SIZE_MIB: 32768
+    # limit VM memory to 8GB, or the host total memory, whichever is lower
+    MEM_SIZE_MIB: 8192
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,38 +29,77 @@ x-runner-vm:
 
 services:
 
-  runner-jammy-1:
+  # container runners are only suitable for private repositories
+
+  jammy-1:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.8.87
 
-  runner-jammy-2:
+  jammy-2:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.8.87
 
-  runner-focal-1:
+  focal-1:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal
 
-  runner-focal-2:
+  focal-2:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal
 
-  runner-jammy-vm-1:
-    <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+  # focal-vm is the equivalent of ubuntu-20.04
 
-  runner-jammy-vm-2:
-    <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
-
-  runner-focal-vm-1:
+  focal-vm-1:
     <<: *runner-vm
     image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal-vm
 
-  runner-focal-vm-2:
+  focal-vm-2:
     <<: *runner-vm
     image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal-vm
 
+  focal-vm-3:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal-vm
+
+  focal-vm-4:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-focal-vm
+
+  # jammy-vm is the equivalent of ubuntu-22.04(-latest)
+
+  jammy-vm-1:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-2:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-3:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-4:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-5:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-6:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-7:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  jammy-vm-8:
+    <<: *runner-vm
+    image: ghcr.io/product-os/self-hosted-runners:3.8.87-jammy-vm
+
+  # inspects the runner logs and sets the supervisor lock if jobs are running
   lock-manager:
     build: lock-manager
     labels:


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/345752-balena-io.2Finternal-tooling/topic/10x.20scale.20GitHub.20self-hosted.20runners
See: https://balena.fibery.io/Inputs/Research/10x-scale-GitHub-self-hosted-runners-606