### PR TITLE
Update VM images to ghcr.io/product-os/github-runner-vm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,53 +53,53 @@ services:
 
   focal-vm-1:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-focal-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42-focal
 
   focal-vm-2:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-focal-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42-focal
 
   focal-vm-3:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-focal-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42-focal
 
   focal-vm-4:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-focal-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42-focal
 
   # jammy-vm is the equivalent of ubuntu-22.04(-latest)
 
   jammy-vm-1:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-2:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-3:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-4:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-5:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-6:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-7:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   jammy-vm-8:
     <<: *runner-vm
-    image: ghcr.io/product-os/self-hosted-runners:3.9.1-jammy-vm
+    image: ghcr.io/product-os/github-runner-vm:0.0.42
 
   # inspects the runner logs and sets the supervisor lock if jobs are running
   lock-manager:


### PR DESCRIPTION
VM images are now being generated from a separate repo.

Change-type: patch