### PR TITLE
Reduce the count of runners per server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,15 +37,7 @@ services:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.10.6
 
-  jammy-2:
-    <<: *runner-container
-    image: ghcr.io/product-os/self-hosted-runners:3.10.6
-
   focal-1:
-    <<: *runner-container
-    image: ghcr.io/product-os/self-hosted-runners:3.10.6-focal
-
-  focal-2:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:3.10.6-focal
 
@@ -56,14 +48,6 @@ services:
     image: ghcr.io/product-os/github-runner-vm:0.2.15-focal
 
   focal-vm-2:
-    <<: *runner-vm
-    image: ghcr.io/product-os/github-runner-vm:0.2.15-focal
-
-  focal-vm-3:
-    <<: *runner-vm
-    image: ghcr.io/product-os/github-runner-vm:0.2.15-focal
-
-  focal-vm-4:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:0.2.15-focal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ x-runner-vm:
     # register to the self-hosted runner group allowed on public repositories
     ACTIONS_RUNNER_GROUP: self-hosted
     DOCKER_REGISTRY_MIRROR: https://nfs.product-os.io
-    # limit VM memory to 8GB, or the host total memory, whichever is lower
-    MEM_SIZE_MIB: 8192
+    # limit VM memory to 32GB, or the host total memory, whichever is lower
+    MEM_SIZE_MIB: 32768
 
 services:
 


### PR DESCRIPTION
Specifically 2 container runners and 2 focal vm runners
should be enough.

Also runners with 8GB were unreliable and disconnected
from GitHub as soon as we gave them a big build. This can be
adjusted via the env var in balenaCloud.

Change-type: patch