### PR TITLE
Do not use tmpfs for root filesystem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ x-runner-vm:
   tmpfs:
     - /tmp
     - /run
-    - /srv
   environment:
     ACTIONS_RUNNER_REGISTRATION_SLUG: enterprises/balena
     # register to the self-hosted runner group allowed on public repositories


### PR DESCRIPTION
The rootfs is rebuilt on every run anyway, so using a tmpfs mount is not necessary and actually uses
way more memory than needed.

Change-type: patch
See: https://github.com/product-os/github-runner-vm/pull/31