### PR TITLE
Give more memory to container runners

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ x-runner-container:
   # to increase or reduce the container's weight, and give it access to
   # a greater or lesser proportion of the host machine's CPU cycles.
   # This is only enforced when CPU cycles are constrained.
-  cpu_shares: 256
-  mem_limit: 4g
+  cpu_shares: 512
+  mem_limit: 8g
   environment:
     ACTIONS_RUNNER_REGISTRATION_SLUG: enterprises/balena
     DOCKER_REGISTRY_MIRROR: https://nfs.product-os.io


### PR DESCRIPTION
Currently the container runners are required to build self-hosted VMs on ARM, and they are running out of memory during the Docker build.

Change-type: patch