### PR TITLE
Use bridge networking for VM runners

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ x-runner-container:
 x-runner-vm:
   &runner-vm
   privileged: true
-  network_mode: host
+  sysctls:
+    - net.ipv4.ip_forward=1
   tmpfs:
     - /tmp
     - /run


### PR DESCRIPTION
This removes the need for cleanup of old iptables rules and potentially allows local-only services like a registry mirror to be available on the VM bridge network.

Change-type: patch