### PR TITLE
Remove the registry cache healthcheck for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,11 +91,6 @@ services:
       # REGISTRY_PROXY_USERNAME: changeme
       # REGISTRY_PROXY_PASSWORD: changeme
       # REGISTRY_LOG_LEVEL: debug
-    healthcheck:
-      test: curl --silent --fail http://localhost:5000/v2/_catalog
-      interval: 1m
-      timeout: 10s
-      retries: 3
 
 volumes:
   registry-data: {}


### PR DESCRIPTION
Curl is not installed in the image so the healthcheck is failing. We can add curl and restore the healthcheck in the future if needed.

Change-type: patch