### PR TITLE
Allow containerized runners to load kernel modules on the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "2.4"
 x-runner-container:
   &runner-container
   privileged: true
+  labels:
+    # Allow CI pipelines to load kernel modules on the host
+    io.balena.features.kernel-modules: '1'
   tmpfs:
     - /tmp
     - /run


### PR DESCRIPTION
This unblocks CI testing of NFS server features where the nfsd module is not loaded by default in balenaOS.

The containerized runners are already privileged, and only
enabled on private repos, so this is not a security change.

Change-type: patch