### PR TITLE
Remove extra jammy runners

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,14 +81,6 @@ services:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:1.2.4
 
-  runner-jammy-7:
-    <<: *runner-vm
-    image: ghcr.io/product-os/github-runner-vm:1.2.4
-
-  runner-jammy-8:
-    <<: *runner-vm
-    image: ghcr.io/product-os/github-runner-vm:1.2.4
-
   # https://distribution.github.io/distribution/recipes/mirror/
   registry-cache:
     image: registry:2.8.3


### PR DESCRIPTION
The current hardware specs have 125G and 250G memory and it splits much more nicely 8 ways instead of 10.

Change-type: patch