### PR TITLE
Remove legacy registry cache and use local service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-runner-container:
     - /scratch
   environment:
     ACTIONS_RUNNER_REGISTRATION_SLUG: enterprises/balena
-    REGISTRY_MIRRORS: http://registry-cache:5000 https://nfs.product-os.io
+    REGISTRY_MIRRORS: http://registry-cache:5000
     INSECURE_REGISTRIES: registry-cache:5000
     # container runners are only suitable for private repositories
     ACTIONS_RUNNER_GROUP: self-hosted-internal
@@ -35,7 +35,7 @@ x-runner-vm:
     - /tmp
   environment:
     ACTIONS_RUNNER_REGISTRATION_SLUG: enterprises/balena
-    REGISTRY_MIRRORS: http://registry-cache:5000 https://nfs.product-os.io
+    REGISTRY_MIRRORS: http://registry-cache:5000
     INSECURE_REGISTRIES: registry-cache:5000
     ACTIONS_RUNNER_GROUP: self-hosted
 


### PR DESCRIPTION
Since github-runner-vm [v2.1.0](https://github.com/product-os/github-runner-vm/releases/tag/v2.1.0) we are assigning random IP subnets to the guest Docker daemon and no longer see any routing issues reaching the local registry-cache service.

Change-type: patch
See: https://github.com/product-os/github-runner-vm/issues/115