### PR TITLE
Disable the blob descriptor cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,9 @@ services:
       # REGISTRY_PROXY_USERNAME: changeme
       # REGISTRY_PROXY_PASSWORD: changeme
       # REGISTRY_LOG_LEVEL: debug
+      # Disable the blob descriptor cache by setting REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR=blah where blah is not inmemory or redis
+      # https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361
+      REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR: blah
 
   # tag devices
   tag-sidecar:


### PR DESCRIPTION
We are starting to see images fail to pull with the error `failed to solve: failed to read expected number of bytes: unexpected EOF`.

This change is reported to be a workaround for that issue.

Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/348930-balena-io.2Fflowzone/topic/flowzone.20docker.20pull.20EOF/near/46966159
See: https://balena.fibery.io/Inputs/Pattern/cloud-builders-failed-to-read-expected-number-of-bytes-unexpected-EOF-4967
See: https://balena.fibery.io/Work/Improvement/Disable-the-blob-descriptor-cache-for-Github-runner-fleets-2132