### PR TITLE
Replace one containerized runner with a noble VM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,6 @@ services:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:6.1.33-jammy
 
-  runner-container-2:
-    <<: *runner-container
-    image: ghcr.io/product-os/self-hosted-runners:6.1.33-jammy
-
   runner-focal-1:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.1.10-focal
@@ -73,11 +69,15 @@ services:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.1.10-jammy
 
-  runner-noble-5:
+  runner-noble-1:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.1.10-noble
 
-  runner-noble-6:
+  runner-noble-2:
+    <<: *runner-vm
+    image: ghcr.io/product-os/github-runner-vm:2.1.10-noble
+
+  runner-noble-3:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.1.10-noble
 


### PR DESCRIPTION
We have a lot more runner servers available now, and we don't have the need for containerized runners as much as VMs. The former is only enabled on a small set of private repos since they are insecure.