### PR TITLE
Reduce the yocto-cache lifecycle policy from 7 days to 3

### DIFF
--- a/minio-init/config/group_vars/all.yml
+++ b/minio-init/config/group_vars/all.yml
@@ -14,7 +14,7 @@ minio_buckets:
   - name: "yocto-cache"
     state: present
     versioning: suspend
-    lifecycle_file: "/config/lifecycles/expiration-7-days.json"
+    lifecycle_file: "/config/lifecycles/expiration-3-days.json"
 
 minio_users:
   - name: "actions-user"

--- a/minio-init/config/lifecycles/expiration-3-days.json
+++ b/minio-init/config/lifecycles/expiration-3-days.json
@@ -1,0 +1,11 @@
+{
+  "Rules": [
+    {
+      "ID": "expiration-3-days",
+      "Status": "Enabled",
+      "Expiration": {
+        "Days": 3
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently we are caching both downloads and sstate which is often ~12GB per cache key, and they add up fast.

Change-type: patch