### PR TITLE
Reduce the yocto-cache lifecycle from 3 days to 1

### DIFF
--- a/minio-init/config/group_vars/all.yml
+++ b/minio-init/config/group_vars/all.yml
@@ -14,7 +14,7 @@ minio_buckets:
   - name: "yocto-cache"
     state: present
     versioning: suspend
-    lifecycle_file: "/config/lifecycles/expiration-3-days.json"
+    lifecycle_file: "/config/lifecycles/expiration-1-days.json"
 
 minio_users:
   - name: "actions-user"

--- a/minio-init/config/lifecycles/expiration-1-days.json
+++ b/minio-init/config/lifecycles/expiration-1-days.json
@@ -1,0 +1,11 @@
+{
+  "Rules": [
+    {
+      "ID": "expiration-1-days",
+      "Status": "Enabled",
+      "Expiration": {
+        "Days": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently we are exceeding 1TB in under 3 days because we are caching yocto sources in addition to sstate cache.

Once we start mirroring yocto sources to AWS S3 we can revert this change.

See: https://balena.fibery.io/Work/Improvement/Update-yocto-workflow-to-use-S3-as-download-mirror-2466