### PR TITLE
Update metrics-agent healthcheck endpoint.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,7 +313,7 @@ services:
     volumes:
       - certs:/certs:ro
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:9273/metrics"]
+      test: ["CMD", "curl", "--fail", "http://localhost:9274"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This makes the engine healthcheck to use the /health endpoint which provides a faster response and is more efficient.

Requires balena-io/metrics-agent#3 to be merged.

Change-type: patch