### PR TITLE
Replace Focal runner with another Noble

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,10 +50,6 @@ services:
     <<: *runner-container
     image: ghcr.io/product-os/self-hosted-runners:6.4.0-jammy
 
-  runner-focal-1:
-    <<: *runner-vm
-    image: ghcr.io/product-os/github-runner-vm:2.4.7-focal
-
   runner-jammy-1:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.4.7-jammy
@@ -75,6 +71,10 @@ services:
     image: ghcr.io/product-os/github-runner-vm:2.4.7-noble
 
   runner-noble-3:
+    <<: *runner-vm
+    image: ghcr.io/product-os/github-runner-vm:2.4.7-noble
+
+  runner-noble-4:
     <<: *runner-vm
     image: ghcr.io/product-os/github-runner-vm:2.4.7-noble
 


### PR DESCRIPTION
GitHub is ending support for Ubuntu 20.04 runners
on April 1, 2025 and we should follow suit.

Change-type: minor
See: https://balena.fibery.io/Work/Project/Discontinue-Focal-self-hosted-runners-1181