### PR TITLE
patch: Offline runner cleanup task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,37 @@ services:
       # https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5194
       OTEL_TRACES_EXPORTER: none
 
+  # clean-up offline Enterprise runners every ~1h
+  delete-offline-runners:
+    build: runners-cleanup
+    restart: no
+    entrypoint: ["/usr/local/bin/bash", "-c"]
+    command:
+      - |
+        set -x
+
+        if [[ -n "${GH_TOKEN}" ]] && [[ -n "${ACTIONS_RUNNER_REGISTRATION_SLUG}" ]]; then
+            gh auth refresh -h github.com -s repo && gh auth status
+            while true; do
+                gh api --paginate \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    "/${ACTIONS_RUNNER_REGISTRATION_SLUG}/actions/runners" |
+                    jq -r '.runners[] | select(.status=="offline").id' |
+                    xargs -I{} gh api --method DELETE \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        /"${ACTIONS_RUNNER_REGISTRATION_SLUG}"/actions/runners/{}
+
+                sleep $(((RANDOM % CHECK_FREQUENCY) + CHECK_JITTER))s
+            done
+        else
+            sleep infinity
+        fi
+
+    environment:
+      CHECK_FREQUENCY: "3600"
+      CHECK_JITTER: "300"
+
   # tag devices
   tag-sidecar:
     image: bash:alpine3.14

--- a/runners-cleanup/Dockerfile
+++ b/runners-cleanup/Dockerfile
@@ -1,0 +1,4 @@
+# https://hub.docker.com/_/bash
+FROM bash:alpine3.22
+
+RUN apk add --no-cache github-cli jq


### PR DESCRIPTION
https://balena.fibery.io/Work/Project/Unregister-runner-from-GitHub-on-teardown-1774

https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/aarch64-self-hosted-runners-doesn't-pick-up-jobs-115

https://balena.fibery.io/Work/Project/Anton-works-1422
